### PR TITLE
#35 메인페이지 마일스톤 컴포넌트 구현

### DIFF
--- a/frontend/src/adminComponents/Footer/index.tsx
+++ b/frontend/src/adminComponents/Footer/index.tsx
@@ -4,7 +4,7 @@ const Footer = () => (
   <div
     style={{
       padding: '8px',
-      font: FONT_STYLE.sm,
+      font: FONT_STYLE.sm.normal,
       color: COLOR.comment,
       textAlign: 'center',
     }}

--- a/frontend/src/adminComponents/Header/components/UserName/index.tsx
+++ b/frontend/src/adminComponents/Header/components/UserName/index.tsx
@@ -7,7 +7,7 @@ const UserName = () => {
   const auth = useAppSelector((state) => state.auth).value;
 
   return (
-    <span style={{ font: FONT_STYLE.xs, color: COLOR.comment, display: 'flex', alignItems: 'center' }}>
+    <span style={{ font: FONT_STYLE.xs.normal, color: COLOR.comment, display: 'flex', alignItems: 'center' }}>
       반갑습니다! <span style={{ color: COLOR.primary.main }}>{auth.username}</span>님
     </span>
   );

--- a/frontend/src/adminComponents/Header/index.tsx
+++ b/frontend/src/adminComponents/Header/index.tsx
@@ -18,10 +18,10 @@ const Header = () => (
       </div>
       <div style={{ display: 'flex', gap: '10px' }}>
         <UserName />
-        <AdminGrayLink href="/" style={{ font: FONT_STYLE.xs, border: 'none', borderRadius: BORDER_RADIUS.lg }}>
+        <AdminGrayLink href="/" style={{ font: FONT_STYLE.xs.normal, border: 'none', borderRadius: BORDER_RADIUS.lg }}>
           사이트 메인으로
         </AdminGrayLink>
-        <AdminBlackLink href="/sign-out" style={{ font: FONT_STYLE.xs, borderRadius: BORDER_RADIUS.lg }}>
+        <AdminBlackLink href="/sign-out" style={{ font: FONT_STYLE.xs.normal, borderRadius: BORDER_RADIUS.lg }}>
           로그아웃
         </AdminBlackLink>
       </div>

--- a/frontend/src/adminConstants.ts
+++ b/frontend/src/adminConstants.ts
@@ -23,8 +23,16 @@ export const COLOR = {
 };
 
 export const FONT_STYLE = {
-  xs: '12px "Noto Sans KR", sans-serif',
-  sm: '14px "Noto Sans KR", sans-serif',
+  xs: {
+    normal: '400 12px "Noto Sans KR", sans-serif',
+    semibold: '600 12px "Noto Sans KR", sans-serif',
+    bold: '700 12px "Noto Sans KR", sans-serif',
+  },
+  sm: {
+    normal: '400 14px "Noto Sans KR", sans-serif',
+    semibold: '600 14px "Noto Sans KR", sans-serif',
+    bold: '700 14px "Noto Sans KR", sans-serif',
+  },
   base: {
     normal: '400 16px "Noto Sans KR", sans-serif',
     semibold: '600 16px "Noto Sans KR", sans-serif',

--- a/frontend/src/app/(auth)/sign-in/page.tsx
+++ b/frontend/src/app/(auth)/sign-in/page.tsx
@@ -1,14 +1,20 @@
+/* eslint-disable implicit-arrow-linebreak */
+/* eslint-disable react-hooks/exhaustive-deps */
+
 'use client';
 
 import { useRouter } from 'next/navigation';
 
 import { FONT_STYLE } from '@/constants';
-import { useAppDispatch } from '@/hocks/redux';
+import { useAppDispatch, useAppSelector } from '@/hocks/redux';
 import { signIn } from '@/store/auth.slice';
 
 const Page = () => {
   const router = useRouter();
   const dispatch = useAppDispatch();
+  const auth = useAppSelector((state) => state.auth).value;
+
+  if (auth.isAuth) router.push('/');
 
   const handleSignInClick = () => {
     // TODO: api 연결
@@ -20,8 +26,11 @@ const Page = () => {
         isModerator: true,
       }),
     );
-    router.back();
+    setTimeout(() => {
+      router.refresh();
+    }, 0);
   };
+
   return (
     <div
       style={{

--- a/frontend/src/app/(auth)/sign-out/page.tsx
+++ b/frontend/src/app/(auth)/sign-out/page.tsx
@@ -3,21 +3,24 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
 
-import { useAppDispatch } from '@/hocks/redux';
+import { useAppDispatch, useAppSelector } from '@/hocks/redux';
 import { signOut } from '@/store/auth.slice';
 
 const Page = () => {
   const router = useRouter();
   const dispatch = useAppDispatch();
+  const auth = useAppSelector((state) => state.auth).value;
 
-  useEffect(() => {
-    // TODO: api 연결
-    dispatch(signOut());
-    router.push('/');
-  }, []);
-  return <div>로그아웃 페이지</div>;
+  if (!auth.isAuth) router.push('/');
+
+  // TODO: api 연결
+  dispatch(signOut());
+  setTimeout(() => {
+    router.refresh();
+  }, 0);
+
+  return null;
 };
 
 export default Page;

--- a/frontend/src/app/components/GoPageIcon/index.tsx
+++ b/frontend/src/app/components/GoPageIcon/index.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+import { VscAdd } from 'react-icons/vsc';
+
+import { COLOR, FONT_STYLE } from '@/constants';
+
+interface GoPageIconProps {
+  name: string;
+  url: string;
+}
+
+const GoPageIcon = ({ name, url }: GoPageIconProps) => (
+  <Link
+    href={url}
+    style={{
+      display: 'flex',
+      color: COLOR.comment,
+      font: FONT_STYLE.sm.semibold,
+      alignItems: 'center',
+      gap: '4px',
+    }}
+  >
+    <VscAdd />
+    {name}
+  </Link>
+);
+
+export default GoPageIcon;

--- a/frontend/src/app/components/Milestone/index.tsx
+++ b/frontend/src/app/components/Milestone/index.tsx
@@ -1,12 +1,28 @@
-import SignIn from '../SignIn';
-import { Description, Title } from '../styled';
+import MilestoneChart from '@/components/MilestoneChart';
+import { AuthSliceState } from '@/store/auth.slice';
+import { getAuthFromCookie } from '@/utils';
 
-const Milestone = () => (
-  <div style={{ display: 'flex', flexDirection: 'column' }}>
-    <Title>나의 마일스톤</Title>
-    <Description>나의 마일스톤 내역을 확인할 수 있어요.</Description>
-    <SignIn />
-  </div>
-);
+import GoPageIcon from '../GoPageIcon';
+import SignIn from '../SignIn';
+import { Description, Title, TitleContent, TitleWrapper } from '../styled';
+
+const Milestone = () => {
+  const auth: AuthSliceState = getAuthFromCookie();
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <TitleWrapper style={{ justifyContent: 'space-between' }}>
+        <TitleContent>
+          <Title>나의 마일스톤</Title>
+          <Description>나의 마일스톤 내역을 확인할 수 있어요.</Description>
+        </TitleContent>
+        {/* TODO: url 자신의 마일스톤으로 이동하도록 수정하기 */}
+        {auth.isAuth && <GoPageIcon name="전체보기" url="/" />}
+      </TitleWrapper>
+      {auth.isAuth && <MilestoneChart />}
+      {!auth.isAuth && <SignIn />}
+    </div>
+  );
+};
 
 export default Milestone;

--- a/frontend/src/app/components/SignIn/components/InputUserInfo/index.tsx
+++ b/frontend/src/app/components/SignIn/components/InputUserInfo/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 import { useAppDispatch } from '@/hocks/redux';
@@ -11,6 +12,7 @@ const InputUserInfo = () => {
   const [userID, setUserID] = useState<string>('');
   const [userPW, setUserPW] = useState<string>('');
 
+  const router = useRouter();
   const dispatch = useAppDispatch();
 
   const handleSignInClick = () => {
@@ -23,6 +25,9 @@ const InputUserInfo = () => {
         isModerator: true,
       }),
     );
+    setTimeout(() => {
+      router.refresh();
+    }, 0);
   };
 
   return (

--- a/frontend/src/app/components/SignIn/components/InputUserInfo/styled.ts
+++ b/frontend/src/app/components/SignIn/components/InputUserInfo/styled.ts
@@ -31,7 +31,7 @@ export const FixedEmail = styled.div`
   right: 10px;
   top: 25%;
   transform: translate(0, -50%);
-  font: ${FONT_STYLE.xs};
+  font: ${FONT_STYLE.xs.normal};
 `;
 
 export const SignInButton = styled.button`

--- a/frontend/src/app/components/SignIn/index.tsx
+++ b/frontend/src/app/components/SignIn/index.tsx
@@ -11,7 +11,7 @@ const SignIn = () => (
       <Divisor>
         <FindLink href="/find-id">아이디</FindLink> / <FindLink href="/find-pw">비밀번호</FindLink> 찾기
       </Divisor>
-      <div style={{ font: FONT_STYLE.xs }}>
+      <div style={{ font: FONT_STYLE.xs.normal }}>
         처음오셨나요? <SignUpLink href="/sign-up">회원가입</SignUpLink>
       </div>
     </SuggestionComment>

--- a/frontend/src/app/components/SignIn/styled.ts
+++ b/frontend/src/app/components/SignIn/styled.ts
@@ -15,12 +15,12 @@ export const AlertComment = styled.div`
 `;
 
 export const FindLink = styled(Link)`
-  font: ${FONT_STYLE.xs};
+  font: ${FONT_STYLE.xs.normal};
   color: ${COLOR.comment};
 `;
 
 export const SignUpLink = styled(Link)`
-  font: ${FONT_STYLE.xs};
+  font: ${FONT_STYLE.xs.normal};
   color: ${COLOR.comment};
   text-decoration: underline;
 `;
@@ -34,7 +34,7 @@ export const SuggestionComment = styled.div`
 
 export const Divisor = styled.div`
   position: relative;
-  font: ${FONT_STYLE.xs};
+  font: ${FONT_STYLE.xs.normal};
   z-index: 0;
 
   &::after {

--- a/frontend/src/app/components/styled.ts
+++ b/frontend/src/app/components/styled.ts
@@ -4,8 +4,17 @@ import styled from 'styled-components';
 
 import { COLOR, FONT_STYLE } from '@/constants';
 
+export const TitleWrapper = styled.div`
+  display: flex;
+`;
+
+export const TitleContent = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
 export const Title = styled.p`
-  font: ${FONT_STYLE.xl.semibold};
+  font: ${FONT_STYLE.lg.semibold};
 `;
 
 export const Description = styled.p`

--- a/frontend/src/app/components/styled.ts
+++ b/frontend/src/app/components/styled.ts
@@ -9,6 +9,6 @@ export const Title = styled.p`
 `;
 
 export const Description = styled.p`
-  font: ${FONT_STYLE.sm};
+  font: ${FONT_STYLE.sm.normal};
   color: ${COLOR.comment};
 `;

--- a/frontend/src/app/styled.ts
+++ b/frontend/src/app/styled.ts
@@ -33,7 +33,8 @@ export const FlexWrapper = styled.div`
 `;
 
 export const MilestoneWrapper = styled(ContentWrapper)`
-  width: 600px;
+  width: 380px;
+  flex-shrink: 0;
   @media screen and (max-width: ${RESPONSIVE_WIDTH.tablet}) {
     width: 100%;
   }

--- a/frontend/src/components/Footer/styled.ts
+++ b/frontend/src/components/Footer/styled.ts
@@ -40,14 +40,14 @@ export const FooterDiv = styled.div`
 `;
 
 export const FooterText = styled.p`
-  font: ${FONT_STYLE.sm};
+  font: ${FONT_STYLE.sm.normal};
   color: ${COLOR.comment};
 `;
 
 export const FooterLink = styled(Link)`
   width: fit-content;
   height: fit-content;
-  font: ${FONT_STYLE.sm};
+  font: ${FONT_STYLE.sm.normal};
   color: ${COLOR.comment};
   padding-bottom: 2px;
   border-bottom: 1px solid ${COLOR.comment};

--- a/frontend/src/components/Header/HeaderAccordion/styled.ts
+++ b/frontend/src/components/Header/HeaderAccordion/styled.ts
@@ -37,7 +37,7 @@ export const Accordion = styled.div`
   width: 180px;
   max-height: 0;
   text-align: center;
-  font: ${FONT_STYLE.sm};
+  font: ${FONT_STYLE.sm.normal};
   color: ${COLOR.comment};
   background-color: ${COLOR.white};
   border-bottom-left-radius: ${BORDER_RADIUS.sm};

--- a/frontend/src/components/Header/Sidebar/styled.ts
+++ b/frontend/src/components/Header/Sidebar/styled.ts
@@ -30,7 +30,7 @@ export const HamburgerLine = styled.div`
 export const SidebarContent = styled.div`
   width: 200px;
   height: 100vh;
-  font: ${FONT_STYLE.sm};
+  font: ${FONT_STYLE.sm.normal};
   background-color: ${COLOR.white};
   position: absolute;
   transition: left 0.4s ease-in-out;

--- a/frontend/src/components/Header/styled.ts
+++ b/frontend/src/components/Header/styled.ts
@@ -38,7 +38,7 @@ export const SignButton = styled.div`
 `;
 
 export const SignText = styled.span`
-  font: ${FONT_STYLE.sm};
+  font: ${FONT_STYLE.sm.normal};
   color: ${COLOR.white};
 `;
 

--- a/frontend/src/components/IconButton/index.tsx
+++ b/frontend/src/components/IconButton/index.tsx
@@ -28,7 +28,7 @@ const IconButton = ({ icon, title, size, link }: IconButtonProps) => {
       {Icon}
       <span
         style={{
-          font: `${size === 'sm' ? FONT_STYLE.xs : size === 'md' ? FONT_STYLE.base.normal : FONT_STYLE.lg.normal}`,
+          font: `${size === 'sm' ? FONT_STYLE.xs.normal : size === 'md' ? FONT_STYLE.base.normal : FONT_STYLE.lg.normal}`,
         }}
       >
         {title}

--- a/frontend/src/components/MilestoneChart/index.tsx
+++ b/frontend/src/components/MilestoneChart/index.tsx
@@ -13,19 +13,19 @@ const MilestoneChart = () => {
 
   const scores = [
     {
-      sum: 0,
+      start: 0,
       score: milestoneSummaryInfo.practicalScore,
       color: COLOR.milestone.blue,
       title: '실전적 SW역량',
     },
     {
-      sum: milestoneSummaryInfo.practicalScore,
+      start: milestoneSummaryInfo.practicalScore,
       score: milestoneSummaryInfo.globalScore,
       color: COLOR.milestone.green,
       title: '글로벌 SW역량',
     },
     {
-      sum: milestoneSummaryInfo.practicalScore + milestoneSummaryInfo.globalScore,
+      start: milestoneSummaryInfo.practicalScore + milestoneSummaryInfo.globalScore,
       score: milestoneSummaryInfo.communicationScore,
       color: COLOR.milestone.purple,
       title: '커뮤니티 SW역량',
@@ -36,7 +36,7 @@ const MilestoneChart = () => {
     <S.ChartWrapper>
       <S.Chart size={chartSize}>
         {scores.map((bar) => (
-          <S.ChartBar key={bar.color} sum={bar.sum} score={bar.score} color={bar.color} />
+          <S.ChartBar key={bar.color} start={bar.start} score={bar.score} color={bar.color} />
         ))}
         <S.ChartHole size={chartSize} />
         <S.ChartTextWrapper>

--- a/frontend/src/components/MilestoneChart/index.tsx
+++ b/frontend/src/components/MilestoneChart/index.tsx
@@ -1,0 +1,65 @@
+import { COLOR } from '@/constants';
+import { milestoneSummaryInfo } from '@/mocks/milestone';
+import { AuthSliceState } from '@/store/auth.slice';
+import { getAuthFromCookie } from '@/utils';
+
+import * as S from './styled';
+
+const MilestoneChart = () => {
+  const chartSize = 120;
+
+  const auth: AuthSliceState = getAuthFromCookie();
+  // TODO: getServerSideProps로 api 연결 - 마일스톤 통계 정보 가져오기.
+
+  const scores = [
+    {
+      sum: 0,
+      score: milestoneSummaryInfo.practicalScore,
+      color: COLOR.milestone.blue,
+      title: '실전적 SW역량',
+    },
+    {
+      sum: milestoneSummaryInfo.practicalScore,
+      score: milestoneSummaryInfo.globalScore,
+      color: COLOR.milestone.green,
+      title: '글로벌 SW역량',
+    },
+    {
+      sum: milestoneSummaryInfo.practicalScore + milestoneSummaryInfo.globalScore,
+      score: milestoneSummaryInfo.communicationScore,
+      color: COLOR.milestone.purple,
+      title: '커뮤니티 SW역량',
+    },
+  ];
+
+  return (
+    <S.ChartWrapper>
+      <S.Chart size={chartSize}>
+        {scores.map((bar) => (
+          <S.ChartBar key={bar.color} sum={bar.sum} score={bar.score} color={bar.color} />
+        ))}
+        <S.ChartHole size={chartSize} />
+        <S.ChartTextWrapper>
+          <S.ChartScoreText>50</S.ChartScoreText>
+          <S.ChartText>/ 1000</S.ChartText>
+        </S.ChartTextWrapper>
+      </S.Chart>
+      <S.TableWrapper style={{ alignContent: 'center' }}>
+        <S.TableTitle>역량 구분</S.TableTitle> <S.TableTitle>획득</S.TableTitle>
+        {scores.map((bar) => (
+          <>
+            <S.ScoreContent key={`1-${bar.color}`}>
+              <S.Square size={12} color={bar.color} />
+              {bar.title}
+            </S.ScoreContent>
+            <S.TableBottomBorderContent key={`2-${bar.color}`}>{bar.score}</S.TableBottomBorderContent>
+          </>
+        ))}
+        <S.TableTopBorderContent>합계</S.TableTopBorderContent>
+        <S.TableTopBorderContent>{milestoneSummaryInfo.totalScore}</S.TableTopBorderContent>
+      </S.TableWrapper>
+    </S.ChartWrapper>
+  );
+};
+
+export default MilestoneChart;

--- a/frontend/src/components/MilestoneChart/styled.ts
+++ b/frontend/src/components/MilestoneChart/styled.ts
@@ -9,7 +9,7 @@ interface ChartProps {
 }
 
 interface ChartBarProps {
-  sum: number;
+  start: number;
   score: number;
   color: string;
 }
@@ -41,10 +41,10 @@ export const ChartBar = styled.div<ChartBarProps>`
   height: inherit;
   border-radius: 50%;
   background: conic-gradient(
-    transparent ${(props) => (props.sum / 1000.0) * 360}deg,
-    ${(props) => props.color} ${(props) => (props.sum / 1000.0) * 360}deg,
-    ${(props) => props.color} ${(props) => ((props.sum + props.score) / 1000.0) * 360}deg,
-    transparent ${(props) => ((props.sum + props.score) / 1000.0) * 360}deg
+    transparent ${(props) => (props.start / 1000.0) * 360}deg,
+    ${(props) => props.color} ${(props) => (props.start / 1000.0) * 360}deg,
+    ${(props) => props.color} ${(props) => ((props.start + props.score) / 1000.0) * 360}deg,
+    transparent ${(props) => ((props.start + props.score) / 1000.0) * 360}deg
   );
 `;
 

--- a/frontend/src/components/MilestoneChart/styled.ts
+++ b/frontend/src/components/MilestoneChart/styled.ts
@@ -1,0 +1,123 @@
+'use client';
+
+import styled from 'styled-components';
+
+import { COLOR, FONT_STYLE } from '@/constants';
+
+interface ChartProps {
+  size: number;
+}
+
+interface ChartBarProps {
+  sum: number;
+  score: number;
+  color: string;
+}
+
+interface SquareProps {
+  size: number;
+  color: string;
+}
+
+export const ChartWrapper = styled.div`
+  margin: 12px;
+  display: flex;
+  gap: 20px;
+  align-items: center;
+  justify-content: space-around;
+`;
+
+export const Chart = styled.div<ChartProps>`
+  position: relative;
+  width: ${(props) => props.size}px;
+  height: ${(props) => props.size}px;
+  border-radius: 100%;
+  background: ${COLOR.milestone.gray};
+`;
+
+export const ChartBar = styled.div<ChartBarProps>`
+  position: absolute;
+  width: inherit;
+  height: inherit;
+  border-radius: 50%;
+  background: conic-gradient(
+    transparent ${(props) => (props.sum / 1000.0) * 360}deg,
+    ${(props) => props.color} ${(props) => (props.sum / 1000.0) * 360}deg,
+    ${(props) => props.color} ${(props) => ((props.sum + props.score) / 1000.0) * 360}deg,
+    transparent ${(props) => ((props.sum + props.score) / 1000.0) * 360}deg
+  );
+`;
+
+export const ChartHole = styled.div<ChartProps>`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: ${(props) => props.size / 1.7}px;
+  height: ${(props) => props.size / 1.7}px;
+  border-radius: 100%;
+  background: ${COLOR.white};
+`;
+
+export const ChartTextWrapper = styled.div`
+  position: absolute;
+  top: 45%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 50%;
+  height: 50px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const ChartText = styled.p`
+  color: ${COLOR.comment};
+  font: ${FONT_STYLE.xs.normal};
+`;
+
+export const ChartScoreText = styled(ChartText)`
+  color: ${COLOR.black_text};
+  font: ${FONT_STYLE.base.bold};
+`;
+
+export const TableWrapper = styled.div`
+  flex-grow: 1;
+  max-width: 300px;
+  display: grid;
+  grid-template-columns: 70% 30%;
+  color: ${COLOR.comment};
+  text-align: center;
+  align-content: center;
+`;
+
+export const TableTopBorderContent = styled.div`
+  padding: 4px;
+  border-top: 1px solid ${COLOR.black_text};
+  font: ${FONT_STYLE.xs.normal};
+`;
+
+export const TableBottomBorderContent = styled.div`
+  padding: 4px;
+  border-bottom: 1px solid ${COLOR.border};
+  font: ${FONT_STYLE.xs.normal};
+`;
+
+export const TableTitle = styled(TableBottomBorderContent)`
+  color: ${COLOR.black_text};
+  font: ${FONT_STYLE.xs.semibold};
+`;
+
+export const ScoreContent = styled(TableBottomBorderContent)`
+  display: flex;
+  padding-left: 14px;
+  align-items: center;
+  gap: 4px;
+`;
+
+export const Square = styled.div<SquareProps>`
+  width: ${(props) => props.size}px;
+  height: ${(props) => props.size}px;
+  background: ${(props) => props.color};
+`;

--- a/frontend/src/components/SideBar/styled.ts
+++ b/frontend/src/components/SideBar/styled.ts
@@ -33,7 +33,7 @@ export const SidebarCategoryTitle = styled.p`
 `;
 
 export const SidebarCategoryDescription = styled.p`
-  font: ${FONT_STYLE.sm};
+  font: ${FONT_STYLE.sm.normal};
   color: ${COLOR.comment};
   margin-top: 30px;
   word-break: keep-all;
@@ -79,7 +79,7 @@ export const SidebarCategory = styled(Link)<SidebarCategoryProps>`
     padding: 10px 15px;
     border-bottom: 1px solid ${COLOR.border};
     color: ${COLOR.comment};
-    font: ${FONT_STYLE.sm};
+    font: ${FONT_STYLE.sm.normal};
     ${({ isCurrentCategory }) =>
       isCurrentCategory &&
       `color: ${COLOR.primary.main};

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -30,8 +30,16 @@ export const COLOR = {
 };
 
 export const FONT_STYLE = {
-  xs: '12px "Noto Sans KR", sans-serif',
-  sm: '14px "Noto Sans KR", sans-serif',
+  xs: {
+    normal: '400 12px "Noto Sans KR", sans-serif',
+    semibold: '600 12px "Noto Sans KR", sans-serif',
+    bold: '700 12px "Noto Sans KR", sans-serif',
+  },
+  sm: {
+    normal: '400 14px "Noto Sans KR", sans-serif',
+    semibold: '600 14px "Noto Sans KR", sans-serif',
+    bold: '700 14px "Noto Sans KR", sans-serif',
+  },
   base: {
     normal: '400 16px "Noto Sans KR", sans-serif',
     semibold: '600 16px "Noto Sans KR", sans-serif',

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -27,6 +27,12 @@ export const COLOR = {
     main: '#26325C',
     dark: '#050A1C',
   },
+  milestone: {
+    blue: '#8FA3F8',
+    green: '#9DE6BC',
+    purple: '#AA8CF8',
+    gray: '#F2F2F2',
+  },
 };
 
 export const FONT_STYLE = {

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -6,6 +6,8 @@ export const middleware = (request: NextRequest) => {
   const authJsonStr = request.cookies.get('auth')?.value;
   const auth: AuthSliceState = authJsonStr ? JSON.parse(authJsonStr) : null;
 
+  // TODO: cookie는 사용자가 변조 가능함. 그래서 확인만하는 것이 아닌 검증과증이 필요.
+  // token을 API로 보내 진짜 관리자인지 확인하는 과정 추가하기.
   if ((!auth || !auth.isAuth) && request.nextUrl.pathname.startsWith('/admin')) {
     return Response.redirect(new URL('/sign-in', request.url));
   }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,10 +1,10 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
 import { AuthSliceState } from './store/auth.slice';
+import { getAuthFromCookie } from './utils';
 
 export const middleware = (request: NextRequest) => {
-  const authJsonStr = request.cookies.get('auth')?.value;
-  const auth: AuthSliceState = authJsonStr ? JSON.parse(authJsonStr) : null;
+  const auth: AuthSliceState = getAuthFromCookie();
 
   // TODO: cookie는 사용자가 변조 가능함. 그래서 확인만하는 것이 아닌 검증과증이 필요.
   // token을 API로 보내 진짜 관리자인지 확인하는 과정 추가하기.

--- a/frontend/src/mocks/milestone.ts
+++ b/frontend/src/mocks/milestone.ts
@@ -1,0 +1,8 @@
+import { MilestoneSummary } from '@/types';
+
+export const milestoneSummaryInfo: MilestoneSummary = {
+  practicalScore: 20,
+  globalScore: 40,
+  communicationScore: 60,
+  totalScore: 120,
+};

--- a/frontend/src/store/auth.slice.ts
+++ b/frontend/src/store/auth.slice.ts
@@ -35,19 +35,13 @@ export const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
-    signOut: (state) => {
-      state.value = initialState.value;
-      cookie.save('auth', '', {});
-    },
     signIn: (state, action: PayloadAction<AuthState>) => {
-      state.value = {
-        token: action.payload.token,
-        isAuth: true,
-        username: action.payload.username,
-        uid: action.payload.uid,
-        isModerator: action.payload.isModerator,
-      };
+      cookie.save('auth', JSON.stringify({ ...action.payload, isAuth: true }), {});
+      state.value = { ...action.payload, isAuth: true };
+    },
+    signOut: (state) => {
       cookie.remove('auth');
+      state.value = initialState.value;
     },
   },
 });

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,8 +1,9 @@
+/* eslint-disable implicit-arrow-linebreak */
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { persistReducer, persistStore } from 'redux-persist';
-import storage from 'redux-persist/lib/storage';
 
 import authSlice from './auth.slice';
+import storage from './store';
 
 export const rootReducer = combineReducers({
   auth: authSlice,

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -18,6 +18,10 @@ const persistedReducer = persistReducer(persistConfig, rootReducer);
 
 export const store = configureStore({
   reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: false,
+    }),
 });
 export const persistor = persistStore(store);
 

--- a/frontend/src/store/store.tsx
+++ b/frontend/src/store/store.tsx
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import createWebStorage from 'redux-persist/lib/storage/createWebStorage';
+
+const createNoopStorage = () => ({
+  getItem(_key: any) {
+    return Promise.resolve(null);
+  },
+  setItem(_key: any, value: any) {
+    return Promise.resolve(value);
+  },
+  removeItem(_key: any) {
+    return Promise.resolve();
+  },
+});
+
+const storage = typeof window === 'undefined' ? createNoopStorage() : createWebStorage('local');
+
+export default storage;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -10,3 +10,10 @@ export interface SubCategoryInfo {
   url: string;
   key: string;
 }
+
+export interface MilestoneSummary {
+  practicalScore: number;
+  globalScore: number;
+  communicationScore: number;
+  totalScore: number;
+}

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,0 +1,11 @@
+import { cookies } from 'next/headers';
+
+import { AuthSliceState } from './store/auth.slice';
+
+export const getAuthFromCookie = (): AuthSliceState => {
+  const authJSON = cookies().get('auth')?.value;
+  const auth: AuthSliceState = JSON.parse(
+    authJSON || '{"token": "", "isAuth": false, "username": "", "uid": "", "isModerator": false}',
+  );
+  return auth;
+};


### PR DESCRIPTION
### 관련 이슈
- close #35

### 작업 요약
- 메인페이지의 마일스톤 구현했습니다.
- 마일스톤 차트는 나중에 마이페이지의 마일스톤에서도 사용할 수 있도록 공용 컴포넌트 폴더에 구현했습니다.

### 리뷰 요구 사항
- 리뷰 예상 시간: `15분`

### 미리 보기
<img width="389" alt="스크린샷 2024-06-25 오후 5 12 08" src="https://github.com/SW-CSS/sw-css/assets/77055208/2d3bf6f9-12bd-4beb-9601-fce9092c5ddd">

처음에는 로그인화면이 보이는데요. 로그인 버튼 눌리면 이 UI를 볼 수 있습니다.


border는 신경쓰지 말아주세요! 나중에 다 삭제할 예정입니당!