### PR TITLE
Feature/#36 메인페이지 공지사항 컴포넌트 구현

### DIFF
--- a/frontend/src/app/components/Announcement/index.tsx
+++ b/frontend/src/app/components/Announcement/index.tsx
@@ -1,0 +1,31 @@
+import GoPageIcon from '@/components/GoPageIcon';
+import { announcements } from '@/mocks/announcement';
+
+import { AnnouncementDate, AnnouncementItem, AnnouncementTitle } from './styled';
+import { Description, Title, TitleContent, TitleWrapper } from '../styled';
+
+const Announcement = () => {
+  const ANNOUNCEMENT_URL = 'https://swedu.pusan.ac.kr/swedu/31630/subview.do';
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <TitleWrapper style={{ justifyContent: 'space-between' }}>
+        <TitleContent>
+          <Title>공지사항</Title>
+          <Description>소프트웨어융합교육원의 공지사항을 알려드려요.</Description>
+        </TitleContent>
+        <GoPageIcon name="더보기" url={ANNOUNCEMENT_URL} />
+      </TitleWrapper>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', marginTop: '20px' }}>
+        {announcements.map((item) => (
+          <AnnouncementItem key={item.id} href={item.url}>
+            <AnnouncementTitle>{item.title}</AnnouncementTitle>
+            <AnnouncementDate>{item.date}</AnnouncementDate>
+          </AnnouncementItem>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Announcement;

--- a/frontend/src/app/components/Announcement/styled.ts
+++ b/frontend/src/app/components/Announcement/styled.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import Link from 'next/link';
+import styled from 'styled-components';
+
+import { BORDER_RADIUS, COLOR, FONT_STYLE } from '@/constants';
+
+export const AnnouncementItem = styled(Link)`
+  border: 1px solid ${COLOR.border};
+  border-radius: ${BORDER_RADIUS.sm};
+  padding: 10px;
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  &:hover > * {
+    color: ${COLOR.primary.main};
+  }
+`;
+
+export const AnnouncementTitle = styled.span`
+  min-width: 0;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  font: ${FONT_STYLE.base.semibold};
+  color: ${COLOR.black_text};
+`;
+
+export const AnnouncementDate = styled.span`
+  width: 90px;
+  flex-shirk: 1;
+  text-align: right;
+  font: ${FONT_STYLE.sm.normal};
+  color: ${COLOR.comment};
+`;

--- a/frontend/src/app/components/styled.ts
+++ b/frontend/src/app/components/styled.ts
@@ -4,11 +4,22 @@ import styled from 'styled-components';
 
 import { COLOR, FONT_STYLE } from '@/constants';
 
+export const TitleWrapper = styled.div`
+  display: flex;
+`;
+
+export const TitleContent = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
 export const Title = styled.p`
-  font: ${FONT_STYLE.xl.semibold};
+  font: ${FONT_STYLE.lg.semibold};
+  cursor: default;
 `;
 
 export const Description = styled.p`
-  font: ${FONT_STYLE.sm};
+  font: ${FONT_STYLE.sm.normal};
   color: ${COLOR.comment};
+  cursor: default;
 `;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Announcement from './components/Announcement';
 import Milestone from './components/Milestone';
 import { AnnouncementContent, ContentWrapper, MilestoneWrapper, FlexWrapper, MainPageWrapper } from './styled';
 
@@ -7,7 +8,9 @@ const Page = () => (
       <MilestoneWrapper style={{ border: '2px solid pink' }}>
         <Milestone />
       </MilestoneWrapper>
-      <AnnouncementContent style={{ border: '2px solid pink' }}>announcement</AnnouncementContent>
+      <AnnouncementContent style={{ border: '2px solid pink' }}>
+        <Announcement />
+      </AnnouncementContent>
     </FlexWrapper>
     <ContentWrapper style={{ border: '2px solid pink' }}>linker</ContentWrapper>
     <ContentWrapper style={{ border: '2px solid pink' }}>team building</ContentWrapper>

--- a/frontend/src/app/styled.ts
+++ b/frontend/src/app/styled.ts
@@ -33,7 +33,8 @@ export const FlexWrapper = styled.div`
 `;
 
 export const MilestoneWrapper = styled(ContentWrapper)`
-  width: 600px;
+  width: 380px;
+  flex-shirk: 1;
   @media screen and (max-width: ${RESPONSIVE_WIDTH.tablet}) {
     width: 100%;
   }
@@ -41,4 +42,5 @@ export const MilestoneWrapper = styled(ContentWrapper)`
 
 export const AnnouncementContent = styled(ContentWrapper)`
   flex-grow: 1;
+  min-width: 0;
 `;

--- a/frontend/src/components/GoPageIcon/index.tsx
+++ b/frontend/src/components/GoPageIcon/index.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+import { VscAdd } from 'react-icons/vsc';
+
+import { COLOR, FONT_STYLE } from '@/constants';
+
+interface GoPageIconProps {
+  name: string;
+  url: string;
+}
+
+const GoPageIcon = ({ name, url }: GoPageIconProps) => (
+  <Link
+    href={url}
+    style={{
+      display: 'flex',
+      color: COLOR.comment,
+      font: FONT_STYLE.sm.semibold,
+      alignItems: 'center',
+      gap: '4px',
+    }}
+  >
+    <VscAdd />
+    {name}
+  </Link>
+);
+
+export default GoPageIcon;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -27,11 +27,25 @@ export const COLOR = {
     main: '#26325C',
     dark: '#050A1C',
   },
+  milestone: {
+    blue: '#8FA3F8',
+    green: '#9DE6BC',
+    purple: '#AA8CF8',
+    gray: '#F2F2F2',
+  },
 };
 
 export const FONT_STYLE = {
-  xs: '12px "Noto Sans KR", sans-serif',
-  sm: '14px "Noto Sans KR", sans-serif',
+  xs: {
+    normal: '400 12px "Noto Sans KR", sans-serif',
+    semibold: '600 12px "Noto Sans KR", sans-serif',
+    bold: '700 12px "Noto Sans KR", sans-serif',
+  },
+  sm: {
+    normal: '400 14px "Noto Sans KR", sans-serif',
+    semibold: '600 14px "Noto Sans KR", sans-serif',
+    bold: '700 14px "Noto Sans KR", sans-serif',
+  },
   base: {
     normal: '400 16px "Noto Sans KR", sans-serif',
     semibold: '600 16px "Noto Sans KR", sans-serif',

--- a/frontend/src/mocks/announcement.ts
+++ b/frontend/src/mocks/announcement.ts
@@ -1,0 +1,13 @@
+import { AnnouncementInfo } from '@/types';
+
+export const announcements: AnnouncementInfo[] = [
+  { id: 1, url: '/', title: '[안내] 2024 제1회 전국대학 소프트웨어 성과 공유포럼', date: '2024.06.20' },
+  { id: 2, url: '/', title: '[안내] 2024년 클라우드컴퓨팅 부트캠프 개최 및 참가 추가모집 공고', date: '2024.06.20' },
+  { id: 3, url: '/', title: '[안내] 제5회 PNU 창의융합 소프트웨어해커톤(예선) 심사결과 공지', date: '2024.06.20' },
+  {
+    id: 4,
+    url: '/',
+    title: '[모집]2024 SW중심대학 디지털경진대회 AI부분 선발 기간연장안내(~6.19)',
+    date: '2024.06.20',
+  },
+];

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -10,3 +10,10 @@ export interface SubCategoryInfo {
   url: string;
   key: string;
 }
+
+export interface AnnouncementInfo {
+  id: number;
+  url: string;
+  title: string;
+  date: string;
+}


### PR DESCRIPTION
### 관련 이슈
- 이전 pr 먼저 봐주세요. #35 
- close #36

### 작업 요약
- 메인페이지의 공지사항을 구현했습니다.

### 리뷰 요구 사항
- 리뷰 예상 시간: `15분`
- #35 와 관련에 정의했던 코드가 필요해서 다시 작성했습니다.

### 미리 보기
<img width="1226" alt="image" src="https://github.com/SW-CSS/sw-css/assets/77055208/b367bb45-9f4d-4735-b5dd-a22b67e9fc93">


border는 신경쓰지 말아주세요! 나중에 다 삭제할 예정입니당!