### PR TITLE
Feature/#75 페이지 타이틀 컴포넌트 구현

### DIFF
--- a/frontend/src/app/components/PageTitle/index.tsx
+++ b/frontend/src/app/components/PageTitle/index.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import { VscAdd } from 'react-icons/vsc';
+
+export interface PageTitleProps {
+  title: string;
+  description: string;
+  urlText: string;
+  url: string;
+}
+
+const PageTitle = ({ title, description, urlText, url }: PageTitleProps) => (
+  <div className="flex">
+    <div className="flex flex-col">
+      <p className="cursor-default text-xl font-semibold">{title}</p>
+      <p className="cursor-default text-sm text-comment">{description}</p>
+    </div>
+    <Link href={url} className="flex items-center gap-1 text-sm text-comment">
+      <VscAdd />
+      {urlText}
+    </Link>
+  </div>
+);
+
+export default PageTitle;

--- a/frontend/src/app/components/PageTitle/index.tsx
+++ b/frontend/src/app/components/PageTitle/index.tsx
@@ -9,7 +9,7 @@ export interface PageTitleProps {
 }
 
 const PageTitle = ({ title, description, urlText, url }: PageTitleProps) => (
-  <div className="flex">
+  <div className="flex justify-between">
     <div className="flex flex-col gap-2">
       <p className="cursor-default text-xl font-semibold">{title}</p>
       <p className="cursor-default text-sm text-comment">{description}</p>

--- a/frontend/src/app/components/PageTitle/index.tsx
+++ b/frontend/src/app/components/PageTitle/index.tsx
@@ -10,14 +10,16 @@ export interface PageTitleProps {
 
 const PageTitle = ({ title, description, urlText, url }: PageTitleProps) => (
   <div className="flex">
-    <div className="flex flex-col">
+    <div className="flex flex-col gap-2">
       <p className="cursor-default text-xl font-semibold">{title}</p>
       <p className="cursor-default text-sm text-comment">{description}</p>
     </div>
-    <Link href={url} className="flex items-center gap-1 text-sm text-comment">
-      <VscAdd />
-      {urlText}
-    </Link>
+    {urlText !== '' && (
+      <Link href={url} className="flex items-center gap-1 text-sm text-comment">
+        <VscAdd />
+        {urlText}
+      </Link>
+    )}
   </div>
 );
 


### PR DESCRIPTION
### 관련 이슈
- close #75 

### 작업 요약
- 페이지에 사용되는 title 컴포넌트로 생성

### 리뷰 요구 사항
- 리뷰 예상 시간: `5분`

### 미리 보기
<img width="551" alt="image" src="https://github.com/SW-CSS/sw-css/assets/77055208/a0096eab-9e42-4b52-8777-deac7988c7c4">

`<PageTitle title="공지사항" description="소프트웨어융합교육원의 공지사항을 알려드려요." urlText="" url="" />`


<img width="501" alt="image" src="https://github.com/SW-CSS/sw-css/assets/77055208/0c849dc5-1f1d-40bb-b90c-6379616fca2c">

```tsx
<PageTitle
        title="공지사항"
        description="소프트웨어융합교육원의 공지사항을 알려드려요."
        urlText="더보기"
        url="https://swedu.pusan.ac.kr/swedu/31630/subview.do"
      />
```

