### PR TITLE
Feature/#199 비밀번호 초기화 api 연결

### DIFF
--- a/frontend/src/app/(client)/(auth)/find-password/components/FindForm/index.tsx
+++ b/frontend/src/app/(client)/(auth)/find-password/components/FindForm/index.tsx
@@ -7,6 +7,7 @@ import EmailTextInput from '@/components/Formik/EmailTextInput';
 import TextInput from '@/components/Formik/TextInput';
 import { useResetPasswordMutation } from '@/lib/hooks/useApi';
 import { toast } from 'react-toastify';
+import { useRouter } from 'next/navigation';
 
 const validationSchema = Yup.object().shape({
   email: Yup.string()
@@ -28,6 +29,7 @@ const initialValues: FormType = {
 
 const FindForm = () => {
   const { mutate: resetPasswordMutation } = useResetPasswordMutation();
+  const router = useRouter();
 
   const handleSubmitButtonClick = (values: FormType) => {
     resetPasswordMutation(
@@ -35,6 +37,9 @@ const FindForm = () => {
       {
         onSuccess(data, variables, context) {
           toast.info('임시비밀번호 메일이 발송되었습니다.');
+          setTimeout(function () {
+            router.push('/sign-in');
+          }, 2000);
         },
         onError(error, variables, context) {
           toast.error(error.message);

--- a/frontend/src/app/(client)/(auth)/find-password/components/FindForm/index.tsx
+++ b/frontend/src/app/(client)/(auth)/find-password/components/FindForm/index.tsx
@@ -5,6 +5,8 @@ import * as Yup from 'yup';
 
 import EmailTextInput from '@/components/Formik/EmailTextInput';
 import TextInput from '@/components/Formik/TextInput';
+import { useResetPasswordMutation } from '@/lib/hooks/useApi';
+import { toast } from 'react-toastify';
 
 const validationSchema = Yup.object().shape({
   email: Yup.string()
@@ -25,9 +27,20 @@ const initialValues: FormType = {
 };
 
 const FindForm = () => {
+  const { mutate: resetPasswordMutation } = useResetPasswordMutation();
+
   const handleSubmitButtonClick = (values: FormType) => {
-    // TODO: 메일 발송 api 호출
-    console.log(JSON.stringify(values));
+    resetPasswordMutation(
+      { email: values.email, name: values.name },
+      {
+        onSuccess(data, variables, context) {
+          toast.info('임시비밀번호 메일이 발송되었습니다.');
+        },
+        onError(error, variables, context) {
+          toast.error(error.message);
+        },
+      },
+    );
   };
 
   return (

--- a/frontend/src/app/(client)/(auth)/find-password/components/FindForm/index.tsx
+++ b/frontend/src/app/(client)/(auth)/find-password/components/FindForm/index.tsx
@@ -1,21 +1,12 @@
 'use client';
 
 import { Form, Formik } from 'formik';
-import * as Yup from 'yup';
 
 import EmailTextInput from '@/components/Formik/EmailTextInput';
 import TextInput from '@/components/Formik/TextInput';
 import { useResetPasswordMutation } from '@/lib/hooks/useApi';
 import { toast } from 'react-toastify';
 import { useRouter } from 'next/navigation';
-
-const validationSchema = Yup.object().shape({
-  email: Yup.string()
-    .required('필수 입력란입니다. 이메일을 입력해주세요.')
-    .matches(/^((?!@).)*$/, '부산대 이메일만 가입 가능합니다. 이메일 도메인 부분을 삭제해주세요.')
-    .matches(/^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*$/, '존재하는 이메일인지 확인해주세요.'),
-  name: Yup.string().required('필수 입력란입니다. 이름을 입력해주세요.'),
-});
 
 interface FormType {
   email: string;
@@ -51,7 +42,6 @@ const FindForm = () => {
   return (
     <Formik
       initialValues={initialValues}
-      validationSchema={validationSchema}
       onSubmit={(values, { setSubmitting }) => {
         setSubmitting(false);
         handleSubmitButtonClick(values);

--- a/frontend/src/lib/hooks/useApi.ts
+++ b/frontend/src/lib/hooks/useApi.ts
@@ -286,3 +286,13 @@ export function useSignInMutation() {
         .catch((err) => Promise.reject(err)),
   });
 }
+
+export function useResetPasswordMutation() {
+  return useAxiosMutation({
+    mutationFn: async ({ email, name }: { email: string; name: string }) =>
+      await client
+        .patch(`/sign-in/reset-password`, { email: email + '@pusan.ac.kr', name })
+        .then((res) => res.data)
+        .catch((err) => Promise.reject(err)),
+  });
+}


### PR DESCRIPTION
### 관련 이슈
- close #199 

### 작업 요약
[FRONTEND]
- 비밀번호 초기화 api 연결
- 비밀번호 초기화 form 에서 validate 삭제
- 비밀번호 초기화 성공 시 toast 알림 후 로그인 페이지로 이동하도록 구현

### 리뷰 요구 사항
- 리뷰 예상 시간: `5분`
- 궁금하신 점이 있다면 언제나 물어봐주세요!
- 코드 스타일 잘못 된 것이 있다면 알려주세용!

