### PR TITLE
Feature/#238 교직원 정보 수정 api 구현

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -54,7 +54,7 @@ include::{snippets}/faculty-find-all/http-response.adoc[]
 include::{snippets}/faculty-find-all/response-fields.adoc[]
 
 
-=== `PATCH`: 비밀번호 수정
+=== `PATCH`: 자신의 비밀번호 수정
 
 .HTTP Request
 include::{snippets}/member-change-password/http-request.adoc[]
@@ -64,6 +64,18 @@ include::{snippets}/member-change-password/request-fields.adoc[]
 
 .HTTP Response
 include::{snippets}/member-change-password/http-response.adoc[]
+
+
+=== `PATCH`: 자신의 기본 정보 수정
+
+.HTTP Request
+include::{snippets}/member-change-info/http-request.adoc[]
+
+.Request Body
+include::{snippets}/member-change-info/request-fields.adoc[]
+
+.HTTP Response
+include::{snippets}/member-change-info/http-response.adoc[]
 
 == 학과
 

--- a/backend/src/main/java/sw_css/member/api/MemberController.java
+++ b/backend/src/main/java/sw_css/member/api/MemberController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sw_css.member.application.MemberCommandService;
 import sw_css.member.application.MemberQueryService;
 import sw_css.member.application.dto.request.ChangePasswordRequest;
 import sw_css.member.application.dto.response.StudentMemberResponse;
@@ -24,6 +25,7 @@ import sw_css.utils.annotation.MemberInterface;
 @Transactional
 public class MemberController {
     private final MemberQueryService memberQueryService;
+    private final MemberCommandService memberCommandService;
 
     @GetMapping("/{memberId}")
     public ResponseEntity<StudentMemberResponse> findStudent(@PathVariable final Long memberId) {
@@ -33,7 +35,7 @@ public class MemberController {
     @PatchMapping("/change-password")
     public ResponseEntity<Void> changeMemberPassword(@MemberInterface Member me,
                                                      @RequestBody @Valid ChangePasswordRequest request) {
-        memberQueryService.changePassword(me, request.oldPassword(), request.newPassword());
+        memberCommandService.changePassword(me, request.oldPassword(), request.newPassword());
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/sw_css/member/api/MemberController.java
+++ b/backend/src/main/java/sw_css/member/api/MemberController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sw_css.member.application.MemberCommandService;
 import sw_css.member.application.MemberQueryService;
-import sw_css.member.application.dto.request.ChangePasswordRequest;
+import sw_css.member.application.dto.request.MemberChangePasswordRequest;
 import sw_css.member.application.dto.request.MemberChangeInfoRequest;
 import sw_css.member.application.dto.response.StudentMemberResponse;
 import sw_css.member.domain.Member;
@@ -35,7 +35,7 @@ public class MemberController {
 
     @PatchMapping("/change-password")
     public ResponseEntity<Void> changeMemberPassword(@MemberInterface Member me,
-                                                     @RequestBody @Valid ChangePasswordRequest request) {
+                                                     @RequestBody @Valid MemberChangePasswordRequest request) {
         memberCommandService.changePassword(me, request.oldPassword(), request.newPassword());
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/sw_css/member/api/MemberController.java
+++ b/backend/src/main/java/sw_css/member/api/MemberController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import sw_css.member.application.MemberCommandService;
 import sw_css.member.application.MemberQueryService;
 import sw_css.member.application.dto.request.ChangePasswordRequest;
+import sw_css.member.application.dto.request.MemberChangeInfoRequest;
 import sw_css.member.application.dto.response.StudentMemberResponse;
 import sw_css.member.domain.Member;
 import sw_css.utils.annotation.MemberInterface;
@@ -36,6 +37,13 @@ public class MemberController {
     public ResponseEntity<Void> changeMemberPassword(@MemberInterface Member me,
                                                      @RequestBody @Valid ChangePasswordRequest request) {
         memberCommandService.changePassword(me, request.oldPassword(), request.newPassword());
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/change-info")
+    public ResponseEntity<Void> changeMemberInfo(@MemberInterface Member me,
+                                                 @RequestBody @Valid MemberChangeInfoRequest request){
+        memberCommandService.changeDefaultInfo(me, request.name(), request.phoneNumber());
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/sw_css/member/application/MemberCommandService.java
+++ b/backend/src/main/java/sw_css/member/application/MemberCommandService.java
@@ -1,0 +1,29 @@
+package sw_css.member.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sw_css.member.domain.Member;
+import sw_css.member.domain.embedded.Password;
+import sw_css.member.domain.repository.MemberRepository;
+import sw_css.member.exception.MemberException;
+import sw_css.member.exception.MemberExceptionType;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberCommandService {
+
+    private final MemberRepository memberRepository;
+
+    public void changePassword(Member me, String oldPassword, String newPassword) {
+        if (me.isWrongPassword(oldPassword)) {
+            throw new MemberException(MemberExceptionType.MEMBER_WRONG_PASSWORD);
+        }
+
+        String encodedPassword = Password.encode(newPassword);
+        me.setPassword(encodedPassword);
+
+        memberRepository.save(me);
+    }
+}

--- a/backend/src/main/java/sw_css/member/application/MemberCommandService.java
+++ b/backend/src/main/java/sw_css/member/application/MemberCommandService.java
@@ -26,4 +26,11 @@ public class MemberCommandService {
 
         memberRepository.save(me);
     }
+
+    public void changeDefaultInfo(final Member me, final String name, final String phoneNumber) {
+        me.setName(name);
+        me.setPhoneNumber(phoneNumber);
+
+        memberRepository.save(me);
+    }
 }

--- a/backend/src/main/java/sw_css/member/application/MemberQueryService.java
+++ b/backend/src/main/java/sw_css/member/application/MemberQueryService.java
@@ -24,16 +24,5 @@ public class MemberQueryService {
                 .orElseThrow(() -> new MemberException(MemberExceptionType.NOT_FOUND_STUDENT));
         return StudentMemberResponse.from(student);
     }
-
-    public void changePassword(Member me, String oldPassword, String newPassword) {
-        if (me.isWrongPassword(oldPassword)) {
-            throw new MemberException(MemberExceptionType.MEMBER_WRONG_PASSWORD);
-        }
-
-        String encodedPassword = Password.encode(newPassword);
-        me.setPassword(encodedPassword);
-
-        memberRepository.save(me);
-    }
 }
 

--- a/backend/src/main/java/sw_css/member/application/dto/request/ChangePasswordRequest.java
+++ b/backend/src/main/java/sw_css/member/application/dto/request/ChangePasswordRequest.java
@@ -1,12 +1,13 @@
 package sw_css.member.application.dto.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import sw_css.member.domain.embedded.Password;
 
 public record ChangePasswordRequest(
-        @NotNull(message = "이전 비밀번호 값을 입력해주세요.")
+        @NotBlank(message = "이전 비밀번호 값을 입력해주세요.")
         String oldPassword,
-        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*\\W)[A-Za-z\\d\\W]{6,15}$", message = "비밀번호는 6자에서 15자 이내의 영문, 숫자, 특수문자의 조합이어야 합니다.")
+        @Pattern(regexp = Password.PASSWORD_REGEX, message = Password.PASSWORD_INVALID)
         String newPassword) {
 
     public static ChangePasswordRequest from(String oldPassword, String newPassword) {

--- a/backend/src/main/java/sw_css/member/application/dto/request/MemberChangeInfoRequest.java
+++ b/backend/src/main/java/sw_css/member/application/dto/request/MemberChangeInfoRequest.java
@@ -1,0 +1,12 @@
+package sw_css.member.application.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+import sw_css.member.domain.embedded.PhoneNumber;
+import sw_css.member.domain.embedded.RealName;
+
+public record MemberChangeInfoRequest(
+        @Pattern(regexp = RealName.NAME_REGEX, message = RealName.NAME_INVALID)
+        String name,
+        @Pattern(regexp = PhoneNumber.PHONE_NUMBER_REGEX, message = PhoneNumber.PHONE_NUMBER_INVALID)
+        String phoneNumber) {
+}

--- a/backend/src/main/java/sw_css/member/application/dto/request/MemberChangePasswordRequest.java
+++ b/backend/src/main/java/sw_css/member/application/dto/request/MemberChangePasswordRequest.java
@@ -4,13 +4,13 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import sw_css.member.domain.embedded.Password;
 
-public record ChangePasswordRequest(
+public record MemberChangePasswordRequest(
         @NotBlank(message = "이전 비밀번호 값을 입력해주세요.")
         String oldPassword,
         @Pattern(regexp = Password.PASSWORD_REGEX, message = Password.PASSWORD_INVALID)
         String newPassword) {
 
-    public static ChangePasswordRequest from(String oldPassword, String newPassword) {
-        return new ChangePasswordRequest(oldPassword, newPassword);
+    public static MemberChangePasswordRequest from(String oldPassword, String newPassword) {
+        return new MemberChangePasswordRequest(oldPassword, newPassword);
     }
 }

--- a/backend/src/main/java/sw_css/member/domain/Member.java
+++ b/backend/src/main/java/sw_css/member/domain/Member.java
@@ -27,6 +27,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private String email;
 
+    @Setter(AccessLevel.PUBLIC)
     @Column(nullable = false)
     private String name;
 
@@ -34,6 +35,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
+    @Setter(AccessLevel.PUBLIC)
     @Column(nullable = false)
     private String phoneNumber;
 

--- a/backend/src/main/java/sw_css/member/exception/MemberExceptionType.java
+++ b/backend/src/main/java/sw_css/member/exception/MemberExceptionType.java
@@ -5,7 +5,7 @@ import sw_css.base.BaseExceptionType;
 
 public enum MemberExceptionType implements BaseExceptionType {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
-    MEMBER_WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 잘못되었습니다."),
+    MEMBER_WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "입력한 이전 비밀번호가 일치하지 않습니다."),
     NOT_FOUND_STUDENT(HttpStatus.NOT_FOUND, "해당하는 학생이 존재하지 않습니다."),
     INVALID_SEARCH_FIELD_ID(HttpStatus.BAD_REQUEST, "검색 유형이 올바르지 않습니다."),
     ;

--- a/backend/src/test/java/sw_css/restdocs/RestDocsTest.java
+++ b/backend/src/test/java/sw_css/restdocs/RestDocsTest.java
@@ -33,6 +33,7 @@ import sw_css.hackathon.application.HackathonTeamVoteCommandService;
 import sw_css.hackathon.application.HackathonTeamVoteQueryService;
 import sw_css.helper.ApiTestHelper;
 import sw_css.major.application.MajorQueryService;
+import sw_css.member.application.MemberCommandService;
 import sw_css.member.application.MemberQueryService;
 import sw_css.member.domain.repository.MemberRepository;
 import sw_css.milestone.application.MilestoneHistoryCommandService;
@@ -67,6 +68,9 @@ public abstract class RestDocsTest extends ApiTestHelper {
 
     @MockBean
     protected MemberQueryService memberQueryService;
+
+    @MockBean
+    protected MemberCommandService memberCommandService;
 
     @MockBean
     protected MemberAdminQueryService memberAdminQueryService;

--- a/backend/src/test/java/sw_css/restdocs/docs/MemberApiDocsTest.java
+++ b/backend/src/test/java/sw_css/restdocs/docs/MemberApiDocsTest.java
@@ -23,6 +23,7 @@ import org.springframework.restdocs.payload.ResponseFieldsSnippet;
 import org.springframework.restdocs.request.PathParametersSnippet;
 import sw_css.member.api.MemberController;
 import sw_css.member.application.dto.request.ChangePasswordRequest;
+import sw_css.member.application.dto.request.MemberChangeInfoRequest;
 import sw_css.member.application.dto.response.StudentMemberResponse;
 import sw_css.member.domain.Member;
 import sw_css.restdocs.RestDocsTest;
@@ -89,5 +90,31 @@ public class MemberApiDocsTest extends RestDocsTest {
                         .header(HttpHeaders.AUTHORIZATION, token))
                 .andExpect(status().isNoContent())
                 .andDo(document("member-change-password", requestFields));
+    }
+
+    @Test
+    @DisplayName("[성공] 회원은 이름과 전화번호를 변경할 수 있다.")
+    public void changeDefaultInfo() throws Exception {
+        // given
+        final RequestFieldsSnippet requestFields = requestFields(
+                fieldWithPath("name").type(JsonFieldType.STRING).description("회원의 이름"),
+                fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("회원의 전화번호")
+        );
+
+        final Member me = new Member(1L, "ddang@pusan.ac.kr", "ddang", "qwer1234!", "01012341234");
+        final String token = "Bearer AccessToken";
+
+        final MemberChangeInfoRequest request = new MemberChangeInfoRequest("이다은", "01031315656");
+
+        // when
+        doNothing().when(memberCommandService).changePassword(me, request.name(), request.phoneNumber());
+
+        // then
+        mockMvc.perform(RestDocumentationRequestBuilders.patch("/members/change-info")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isNoContent())
+                .andDo(document("member-change-info", requestFields));
     }
 }

--- a/backend/src/test/java/sw_css/restdocs/docs/MemberApiDocsTest.java
+++ b/backend/src/test/java/sw_css/restdocs/docs/MemberApiDocsTest.java
@@ -22,7 +22,7 @@ import org.springframework.restdocs.payload.RequestFieldsSnippet;
 import org.springframework.restdocs.payload.ResponseFieldsSnippet;
 import org.springframework.restdocs.request.PathParametersSnippet;
 import sw_css.member.api.MemberController;
-import sw_css.member.application.dto.request.ChangePasswordRequest;
+import sw_css.member.application.dto.request.MemberChangePasswordRequest;
 import sw_css.member.application.dto.request.MemberChangeInfoRequest;
 import sw_css.member.application.dto.response.StudentMemberResponse;
 import sw_css.member.domain.Member;
@@ -78,7 +78,7 @@ public class MemberApiDocsTest extends RestDocsTest {
         final String newPassword = "asdf1234!";
         final String token = "Bearer AccessToken";
 
-        final ChangePasswordRequest request = new ChangePasswordRequest(oldPassword, newPassword);
+        final MemberChangePasswordRequest request = new MemberChangePasswordRequest(oldPassword, newPassword);
 
         // when
         doNothing().when(memberCommandService).changePassword(me, oldPassword, newPassword);

--- a/backend/src/test/java/sw_css/restdocs/docs/MemberApiDocsTest.java
+++ b/backend/src/test/java/sw_css/restdocs/docs/MemberApiDocsTest.java
@@ -80,7 +80,7 @@ public class MemberApiDocsTest extends RestDocsTest {
         final ChangePasswordRequest request = new ChangePasswordRequest(oldPassword, newPassword);
 
         // when
-        doNothing().when(memberQueryService).changePassword(me, oldPassword, newPassword);
+        doNothing().when(memberCommandService).changePassword(me, oldPassword, newPassword);
 
         // then
         mockMvc.perform(RestDocumentationRequestBuilders.patch("/members/change-password")


### PR DESCRIPTION
### 관련 이슈
- close #238 

### 작업 요약
[BACKEND]
- 비밀번호 변경 API 위치 이동
- 회원의 기본정보 수정 API 구현

### 리뷰 요구 사항
- 리뷰 예상 시간: `15분`
