### PR TITLE
Feature/#239 학생 정보 수정 api 구현

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -88,6 +88,14 @@ include::{snippets}/member-change-student-detail-info/request-fields.adoc[]
 .HTTP Response
 include::{snippets}/member-change-student-detail-info/http-response.adoc[]
 
+=== `DELETE` : 회원 탈퇴
+
+.HTTP Request
+include::{snippets}/member-delete/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/member-delete/http-response.adoc[]
+
 == 학과
 
 === `GET`: 단과대학 목록 조회

--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -77,6 +77,17 @@ include::{snippets}/member-change-info/request-fields.adoc[]
 .HTTP Response
 include::{snippets}/member-change-info/http-response.adoc[]
 
+=== `PATCH`: 학생의 전공 및 진로 계획 수정
+
+.HTTP Request
+include::{snippets}/member-change-student-detail-info/http-request.adoc[]
+
+.Request Body
+include::{snippets}/member-change-student-detail-info/request-fields.adoc[]
+
+.HTTP Response
+include::{snippets}/member-change-student-detail-info/http-response.adoc[]
+
 == 학과
 
 === `GET`: 단과대학 목록 조회

--- a/backend/src/main/java/sw_css/admin/member/api/MemberAdminController.java
+++ b/backend/src/main/java/sw_css/admin/member/api/MemberAdminController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,8 +25,12 @@ public class MemberAdminController {
     private final MemberAdminQueryService memberAdminQueryService;
 
     @GetMapping("/students")
-    public ResponseEntity<List<StudentMemberResponse>> findAllStudent(@AdminInterface FacultyMember facultyMember) {
-        return ResponseEntity.ok(memberAdminQueryService.findStudentMembers());
+    public ResponseEntity<Page<StudentMemberResponse>> findStudentByPage(
+            @AdminInterface FacultyMember facultyMember,
+            @RequestParam(value = "field", required = false) final Integer field,
+            @RequestParam(value = "keyword", required = false) final String keyword,
+            final Pageable pageable) {
+        return ResponseEntity.ok(memberAdminQueryService.findStudentMembers(field, keyword, pageable));
     }
 
     @GetMapping("/faculties")

--- a/backend/src/main/java/sw_css/admin/member/application/MemberAdminQueryService.java
+++ b/backend/src/main/java/sw_css/admin/member/application/MemberAdminQueryService.java
@@ -21,9 +21,10 @@ public class MemberAdminQueryService {
     private final StudentMemberRepository studentMemberRepository;
     private final FacultyMemberCustomRepository facultyMemberCustomRepository;
 
-    public List<StudentMemberResponse> findStudentMembers() {
-        final List<StudentMember> students = studentMemberRepository.findAll();
-        return students.stream().map(StudentMemberResponse::from).toList();
+    public Page<StudentMemberResponse> findStudentMembers(final Integer field, final String keyword, final Pageable pageable) {
+        final Page<StudentMember> students = studentMemberRepository.findStudentMembers(field, keyword, pageable);
+
+        return StudentMemberResponse.from(students, pageable);
     }
 
     public Page<FacultyMemberResponse> findFacultyMembers(final Integer field, final String keyword, final Pageable pageable) {

--- a/backend/src/main/java/sw_css/member/api/MemberController.java
+++ b/backend/src/main/java/sw_css/member/api/MemberController.java
@@ -15,9 +15,12 @@ import sw_css.member.application.MemberCommandService;
 import sw_css.member.application.MemberQueryService;
 import sw_css.member.application.dto.request.MemberChangePasswordRequest;
 import sw_css.member.application.dto.request.MemberChangeInfoRequest;
+import sw_css.member.application.dto.request.MemberChangeStudentDetailInfoRequest;
 import sw_css.member.application.dto.response.StudentMemberResponse;
 import sw_css.member.domain.Member;
+import sw_css.member.domain.StudentMember;
 import sw_css.utils.annotation.MemberInterface;
+import sw_css.utils.annotation.StudentInterface;
 
 @Validated
 @RequestMapping("/members")
@@ -44,6 +47,13 @@ public class MemberController {
     public ResponseEntity<Void> changeMemberInfo(@MemberInterface Member me,
                                                  @RequestBody @Valid MemberChangeInfoRequest request){
         memberCommandService.changeDefaultInfo(me, request.name(), request.phoneNumber());
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/change-student-detail-info")
+    public ResponseEntity<Void> changeStudentDetailInfo(@StudentInterface StudentMember me,
+                                                        @RequestBody @Valid MemberChangeStudentDetailInfoRequest request){
+        memberCommandService.changeStudentDetailInfo(me, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/sw_css/member/api/MemberController.java
+++ b/backend/src/main/java/sw_css/member/api/MemberController.java
@@ -5,22 +5,26 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sw_css.admin.auth.application.dto.request.DeleteFacultyRequest;
 import sw_css.member.application.MemberCommandService;
 import sw_css.member.application.MemberQueryService;
 import sw_css.member.application.dto.request.MemberChangePasswordRequest;
 import sw_css.member.application.dto.request.MemberChangeInfoRequest;
 import sw_css.member.application.dto.request.MemberChangeStudentDetailInfoRequest;
 import sw_css.member.application.dto.response.StudentMemberResponse;
+import sw_css.member.domain.FacultyMember;
 import sw_css.member.domain.Member;
 import sw_css.member.domain.StudentMember;
 import sw_css.utils.annotation.MemberInterface;
 import sw_css.utils.annotation.StudentInterface;
+import sw_css.utils.annotation.SuperAdminInterface;
 
 @Validated
 @RequestMapping("/members")
@@ -54,6 +58,13 @@ public class MemberController {
     public ResponseEntity<Void> changeStudentDetailInfo(@StudentInterface StudentMember me,
                                                         @RequestBody @Valid MemberChangeStudentDetailInfoRequest request){
         memberCommandService.changeStudentDetailInfo(me, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping()
+    public ResponseEntity<Void> deleteMember(
+            @MemberInterface Member me) {
+        memberCommandService.deleteMember(me);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/sw_css/member/application/MemberCommandService.java
+++ b/backend/src/main/java/sw_css/member/application/MemberCommandService.java
@@ -63,4 +63,9 @@ public class MemberCommandService {
         me.setDetailInfo(major, minor, doubleMinor, careerType, request.careerDetail());
         studentMemberRepository.save(me);
     }
+
+    public void deleteMember(final Member me) {
+        me.delete();
+        memberRepository.save(me);
+    }
 }

--- a/backend/src/main/java/sw_css/member/application/MemberCommandService.java
+++ b/backend/src/main/java/sw_css/member/application/MemberCommandService.java
@@ -3,9 +3,17 @@ package sw_css.member.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import sw_css.auth.exception.AuthException;
+import sw_css.auth.exception.AuthExceptionType;
+import sw_css.major.domain.Major;
+import sw_css.major.domain.repository.MajorRepository;
+import sw_css.member.application.dto.request.MemberChangeStudentDetailInfoRequest;
+import sw_css.member.domain.CareerType;
 import sw_css.member.domain.Member;
+import sw_css.member.domain.StudentMember;
 import sw_css.member.domain.embedded.Password;
 import sw_css.member.domain.repository.MemberRepository;
+import sw_css.member.domain.repository.StudentMemberRepository;
 import sw_css.member.exception.MemberException;
 import sw_css.member.exception.MemberExceptionType;
 
@@ -15,6 +23,8 @@ import sw_css.member.exception.MemberExceptionType;
 public class MemberCommandService {
 
     private final MemberRepository memberRepository;
+    private final MajorRepository majorRepository;
+    private final StudentMemberRepository studentMemberRepository;
 
     public void changePassword(Member me, String oldPassword, String newPassword) {
         if (me.isWrongPassword(oldPassword)) {
@@ -32,5 +42,25 @@ public class MemberCommandService {
         me.setPhoneNumber(phoneNumber);
 
         memberRepository.save(me);
+    }
+
+    public void changeStudentDetailInfo(final StudentMember me, final MemberChangeStudentDetailInfoRequest request) {
+        final Major major = majorRepository.findById(request.majorId())
+                .orElseThrow(() -> new AuthException(AuthExceptionType.MAJOR_NOT_EXIST));
+        final Major minor = request.minorId() == null ? null : majorRepository.findById(request.minorId())
+                .orElseThrow(() -> new AuthException(AuthExceptionType.MAJOR_NOT_EXIST));
+        final Major doubleMinor =
+                request.doubleMajorId() == null ? null : majorRepository.findById(request.doubleMajorId())
+                        .orElseThrow(() -> new AuthException(AuthExceptionType.MAJOR_NOT_EXIST));
+
+        final CareerType careerType;
+        try {
+            careerType = CareerType.valueOf(request.career());
+        } catch (IllegalArgumentException e) {
+            throw new MemberException(MemberExceptionType.INVALID_CAREER_TYPE);
+        }
+
+        me.setDetailInfo(major, minor, doubleMinor, careerType, request.careerDetail());
+        studentMemberRepository.save(me);
     }
 }

--- a/backend/src/main/java/sw_css/member/application/dto/request/MemberChangeStudentDetailInfoRequest.java
+++ b/backend/src/main/java/sw_css/member/application/dto/request/MemberChangeStudentDetailInfoRequest.java
@@ -1,0 +1,15 @@
+package sw_css.member.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record MemberChangeStudentDetailInfoRequest(
+        @NotNull(message = "전공을 선택해주세요.")
+        Long majorId,
+        Long minorId,
+        Long doubleMajorId,
+        @NotBlank(message = "진로 계획 유형을 선택해주세요.")
+        String career,
+        @NotBlank(message = "진로 상세 계획을 입력해주세요.")
+        String careerDetail ) {
+}

--- a/backend/src/main/java/sw_css/member/application/dto/response/StudentMemberResponse.java
+++ b/backend/src/main/java/sw_css/member/application/dto/response/StudentMemberResponse.java
@@ -1,6 +1,11 @@
 package sw_css.member.application.dto.response;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import sw_css.admin.member.application.dto.response.FacultyMemberResponse;
 import sw_css.member.domain.CareerType;
+import sw_css.member.domain.FacultyMember;
 import sw_css.member.domain.StudentMember;
 
 public record StudentMemberResponse(
@@ -19,5 +24,12 @@ public record StudentMemberResponse(
                 student.getMajor().getName(), student.getMinor() != null ? student.getMinor().getName() : "",
                 student.getDoubleMajor() != null ? student.getDoubleMajor().getName() : "",
                 student.getMember().getPhoneNumber(), student.getCareer(), student.getCareerDetail());
+    }
+
+
+    public static Page<StudentMemberResponse> from(final Page<StudentMember> faculties, final Pageable pageable) {
+        return new PageImpl<>(faculties.stream()
+                .map(StudentMemberResponse::from)
+                .toList(), pageable, faculties.getTotalElements());
     }
 }

--- a/backend/src/main/java/sw_css/member/domain/Member.java
+++ b/backend/src/main/java/sw_css/member/domain/Member.java
@@ -55,4 +55,8 @@ public class Member extends BaseEntity {
         return !Password.matches(rawPassword, password);
     }
 
+    public void delete() {
+        this.isDeleted = true;
+    }
+
 }

--- a/backend/src/main/java/sw_css/member/domain/StudentMember.java
+++ b/backend/src/main/java/sw_css/member/domain/StudentMember.java
@@ -12,11 +12,13 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import sw_css.base.BaseEntity;
 import sw_css.major.domain.Major;
 
 @Entity
 @Getter
+@Setter(AccessLevel.PUBLIC)
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StudentMember extends BaseEntity {
@@ -48,5 +50,13 @@ public class StudentMember extends BaseEntity {
 
     public StudentMember(final Long id) {
         this(id, null, null, null, null, null, null);
+    }
+
+    public void setDetailInfo(final Major major, final Major minor, final Major doubleMajor, final CareerType career, final String careerDetail) {
+        this.major = major;
+        this.minor = minor;
+        this.doubleMajor = doubleMajor;
+        this.career = career;
+        this.careerDetail = careerDetail;
     }
 }

--- a/backend/src/main/java/sw_css/member/domain/repository/StudentMemberRepository.java
+++ b/backend/src/main/java/sw_css/member/domain/repository/StudentMemberRepository.java
@@ -1,7 +1,11 @@
 package sw_css.member.domain.repository;
 
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.lang.Nullable;
+import sw_css.member.domain.FacultyMember;
 import sw_css.member.domain.StudentMember;
 
 public interface StudentMemberRepository extends JpaRepository<StudentMember, Long> {
@@ -10,4 +14,9 @@ public interface StudentMemberRepository extends JpaRepository<StudentMember, Lo
     boolean existsByMemberId(Number memberId);
 
     Optional<StudentMember> findByMemberId(Number memberId);
+
+
+    Page<StudentMember> findStudentMembers(@Nullable final Integer field,
+                                           @Nullable final String keyword,
+                                           final Pageable pageable);
 }

--- a/backend/src/main/java/sw_css/member/exception/MemberExceptionType.java
+++ b/backend/src/main/java/sw_css/member/exception/MemberExceptionType.java
@@ -8,6 +8,7 @@ public enum MemberExceptionType implements BaseExceptionType {
     MEMBER_WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "입력한 이전 비밀번호가 일치하지 않습니다."),
     NOT_FOUND_STUDENT(HttpStatus.NOT_FOUND, "해당하는 학생이 존재하지 않습니다."),
     INVALID_SEARCH_FIELD_ID(HttpStatus.BAD_REQUEST, "검색 유형이 올바르지 않습니다."),
+    INVALID_CAREER_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않는 진로 계획 유형 입니다.")
     ;
 
 

--- a/backend/src/test/java/sw_css/restdocs/docs/MemberApiDocsTest.java
+++ b/backend/src/test/java/sw_css/restdocs/docs/MemberApiDocsTest.java
@@ -153,6 +153,23 @@ public class MemberApiDocsTest extends RestDocsTest {
                         .header(HttpHeaders.AUTHORIZATION, token))
                 .andExpect(status().isNoContent())
                 .andDo(document("member-change-student-detail-info", requestFields));
+    }
 
+    @Test
+    @DisplayName("[성공] 회원은 서비스를 탈퇴할 수 있다..")
+    public void deleteMember() throws Exception {
+        // given
+        final Member me = new Member(1L, "ddang@pusan.ac.kr", "ddang", "qwer1234!", "01012341234");
+        final String token = "Bearer AccessToken";
+
+        // when
+        doNothing().when(memberCommandService).deleteMember(me);
+
+        // then
+        mockMvc.perform(RestDocumentationRequestBuilders.delete("/members")
+                        .contentType(APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isNoContent())
+                .andDo(document("member-delete"));
     }
 }

--- a/backend/src/test/java/sw_css/restdocs/docs/MemberApiDocsTest.java
+++ b/backend/src/test/java/sw_css/restdocs/docs/MemberApiDocsTest.java
@@ -21,11 +21,16 @@ import org.springframework.restdocs.payload.PayloadDocumentation;
 import org.springframework.restdocs.payload.RequestFieldsSnippet;
 import org.springframework.restdocs.payload.ResponseFieldsSnippet;
 import org.springframework.restdocs.request.PathParametersSnippet;
+import sw_css.major.domain.College;
+import sw_css.major.domain.Major;
 import sw_css.member.api.MemberController;
 import sw_css.member.application.dto.request.MemberChangePasswordRequest;
 import sw_css.member.application.dto.request.MemberChangeInfoRequest;
+import sw_css.member.application.dto.request.MemberChangeStudentDetailInfoRequest;
 import sw_css.member.application.dto.response.StudentMemberResponse;
+import sw_css.member.domain.CareerType;
 import sw_css.member.domain.Member;
+import sw_css.member.domain.StudentMember;
 import sw_css.restdocs.RestDocsTest;
 
 @WebMvcTest(MemberController.class)
@@ -116,5 +121,38 @@ public class MemberApiDocsTest extends RestDocsTest {
                         .header(HttpHeaders.AUTHORIZATION, token))
                 .andExpect(status().isNoContent())
                 .andDo(document("member-change-info", requestFields));
+    }
+
+    @Test
+    @DisplayName("[성공] 헉생의 자신의 전고 및 진로 계획을 수정할 수 있다.")
+    public void changeStudentDetailInfo() throws Exception {
+        // given
+        final RequestFieldsSnippet requestFields = requestFields(
+                fieldWithPath("majorId").type(JsonFieldType.NUMBER).description("회원의 전공 id"),
+                fieldWithPath("minorId").type(JsonFieldType.NUMBER).description("회원의 부전공 id"),
+                fieldWithPath("doubleMajorId").type(JsonFieldType.NUMBER).description("회원의 복수 전공 id"),
+                fieldWithPath("career").type(JsonFieldType.STRING).description("회원의 진로 계획 유형 - GRADUATE_SCHOOL, EMPLOYMENT_COMPANY, EMPLOYMENT_PUBLIC_INSTITUTION, FOUNDATION"),
+                fieldWithPath("careerDetail").type(JsonFieldType.STRING).description("회원의 진로 상세 계획")
+        );
+
+
+        final StudentMember student = new StudentMember(202055500L,
+                new Member(1L, "abc@naver.com", "홍길동", "password", "010-0000-0000", false),
+                new Major(1L, new College(1L, "인문대학"), "사회학과"), null, null, CareerType.EMPLOYMENT_COMPANY,
+                "IT 사기업 개발자로 취업");
+        final MemberChangeStudentDetailInfoRequest request = new MemberChangeStudentDetailInfoRequest(1L, 2L, 3L, "GRADUATE_SCHOOL", "AI 관련 연구실에서 석박사");
+        final String token = "Bearer AccessToken";
+
+        // when
+        doNothing().when(memberCommandService).changeStudentDetailInfo(student, request);
+
+        // then
+        mockMvc.perform(RestDocumentationRequestBuilders.patch("/members/change-student-detail-info")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isNoContent())
+                .andDo(document("member-change-student-detail-info", requestFields));
+
     }
 }

--- a/backend/src/test/java/sw_css/restdocs/docs/admin/MemberAdminApiDocsTest.java
+++ b/backend/src/test/java/sw_css/restdocs/docs/admin/MemberAdminApiDocsTest.java
@@ -53,34 +53,61 @@ public class MemberAdminApiDocsTest extends RestDocsTest {
     @DisplayName("[성공] 모든 학생들의 정보를 조회할 수 있다.")
     public void findStudents() throws Exception {
         // given
-        final ResponseFieldsSnippet responseFields = PayloadDocumentation.responseFields(
-                fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("학생의 id(학번)"),
-                fieldWithPath("[].email").type(JsonFieldType.STRING).description("학생의 이메일"),
-                fieldWithPath("[].name").type(JsonFieldType.STRING).description("학생의 이름"),
-                fieldWithPath("[].major").type(JsonFieldType.STRING).description("학생의 주전공"),
-                fieldWithPath("[].minor").type(JsonFieldType.STRING).description("학생의 부전공"),
-                fieldWithPath("[].doubleMajor").type(JsonFieldType.STRING).description("학생의 복수전공"),
-                fieldWithPath("[].phoneNumber").type(JsonFieldType.STRING).description("학생의 전화번호"),
-                fieldWithPath("[].career").type(JsonFieldType.STRING).description("학생의 진로 구분"),
-                fieldWithPath("[].careerDetail").type(JsonFieldType.STRING).description("학생의 진로 상세")
+        final QueryParametersSnippet queryParameters = queryParameters(
+                parameterWithName("field").description("검색 필드 번호(option)").optional(),
+                parameterWithName("keyword").description("검색할 키워드(option)").optional()
         );
 
-        final List<StudentMemberResponse> response = List.of(
+        final ResponseFieldsSnippet responseBodySnippet = responseFields(
+                fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("총 페이지 수"),
+                fieldWithPath("totalElements").type(JsonFieldType.NUMBER).description("총 데이터 수"),
+                fieldWithPath("size").type(JsonFieldType.NUMBER).description("페이지 내 데이터 수"),
+                fieldWithPath("number").type(JsonFieldType.NUMBER).description("페이지 번호"),
+                fieldWithPath("sort.empty").type(JsonFieldType.BOOLEAN).description("정렬 속성의 존재 여부"),
+                fieldWithPath("sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬 여부"),
+                fieldWithPath("sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬여부"),
+                fieldWithPath("first").type(JsonFieldType.BOOLEAN).description("첫 페이지인지 여부"),
+                fieldWithPath("last").type(JsonFieldType.BOOLEAN).description("마지막 페이지인지 여부"),
+                fieldWithPath("pageable.pageNumber").type(JsonFieldType.NUMBER).description("요청한 페이지번호"),
+                fieldWithPath("pageable.pageSize").type(JsonFieldType.NUMBER).description("요청한 페이지크기"),
+                fieldWithPath("pageable.sort.empty").type(JsonFieldType.BOOLEAN).description("요청한 데이터가 비었는지 여부"),
+                fieldWithPath("pageable.sort.sorted").type(JsonFieldType.BOOLEAN).description("요청한 데이터 정렬 기준 존재 여부"),
+                fieldWithPath("pageable.sort.unsorted").type(JsonFieldType.BOOLEAN).description("요청한 데이터 정렬 기준 존재 여부"),
+                fieldWithPath("pageable.offset").type(JsonFieldType.NUMBER).description("요청한 페이지오프셋"),
+                fieldWithPath("pageable.paged").type(JsonFieldType.BOOLEAN).description("페이징 여부"),
+                fieldWithPath("pageable.unpaged").type(JsonFieldType.BOOLEAN).description("페이징 여부"),
+                fieldWithPath("numberOfElements").type(JsonFieldType.NUMBER).description("총 데이터 수"),
+                fieldWithPath("empty").type(JsonFieldType.BOOLEAN).description("데이터의 존재 여부"),
+                fieldWithPath("content[].id").type(JsonFieldType.NUMBER).description("학생의 id(학번)"),
+                fieldWithPath("content[].email").type(JsonFieldType.STRING).description("학생의 이메일"),
+                fieldWithPath("content[].name").type(JsonFieldType.STRING).description("학생의 이름"),
+                fieldWithPath("content[].major").type(JsonFieldType.STRING).description("학생의 주전공"),
+                fieldWithPath("content[].minor").type(JsonFieldType.STRING).description("학생의 부전공"),
+                fieldWithPath("content[].doubleMajor").type(JsonFieldType.STRING).description("학생의 복수전공"),
+                fieldWithPath("content[].phoneNumber").type(JsonFieldType.STRING).description("학생의 전화번호"),
+                fieldWithPath("content[].career").type(JsonFieldType.STRING).description("학생의 진로 구분"),
+                fieldWithPath("content[].careerDetail").type(JsonFieldType.STRING).description("학생의 진로 상세")
+        );
+
+        final Pageable pageable = PageRequest.of(0, 10);
+        final Page<StudentMemberResponse> response = new PageImpl<>(List.of(
                 new StudentMemberResponse(202055558L, "songsy405@aaa.com", "홍길동",
                         "정보컴퓨터공학부", "", "", "01011111111", GRADUATE_SCHOOL, "대학원 진학"),
                 new StudentMemberResponse(202055555L, "abcdefg@aaa.com", "아무개",
-                        "사회학과", "", "", "01012345678", EMPLOYMENT_COMPANY, "네카라쿠배"));
-
+                        "사회학과", "", "", "01012345678", EMPLOYMENT_COMPANY, "네카라쿠배")),
+                PageRequest.of(0, 10),
+                2
+        );
         final String token = "Bearer AccessToken";
 
         // when
-        when(memberAdminQueryService.findStudentMembers()).thenReturn(response);
+        when(memberAdminQueryService.findStudentMembers(any(), any(), any())).thenReturn(response);
 
         // then
         mockMvc.perform(RestDocumentationRequestBuilders.get("/admin/member/students")
                         .header(HttpHeaders.AUTHORIZATION, token))
                 .andExpect(status().isOk())
-                .andDo(document("student-find-all", responseFields));
+                .andDo(document("student-find-all", responseBodySnippet));
     }
 
 


### PR DESCRIPTION
### 관련 이슈
- close #239 

### 작업 요약
[BACKEND]
- 회원의 전공 및 진로 계획 수정 API 구현
- 회원 탈퇴 API 구현
- 학생 목록 조회 API 의 반환값 수정

### 리뷰 요구 사항
- 리뷰 예상 시간: `15분`
